### PR TITLE
Publish using the api-key option

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -68,21 +68,12 @@ jobs:
             --api-key ${{ secrets.NUGET_API_KEY }} \
             --skip-duplicate
 
-      - name: Authenticate to GitHub Packages
-        if: matrix.source == 'github'
-        run: |
-          dotnet nuget add source \
-            --username ${{ github.repository_owner }} \
-            --password ${{ secrets.GITHUB_TOKEN }} \
-            --store-password-in-clear-text \
-            --name github \
-            "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json"
-
       - name: Publish to GitHub Packages
         if: matrix.source == 'github'
         run: |
           dotnet nuget push "$PACKAGE_PATTERN" \
-            --source ${{ matrix.source }} \
+            --source https://nuget.pkg.github.com/${{ github.repository_owner }} \
+            --api-key ${{ secrets.GITHUB_TOKEN }} \
             --skip-duplicate
 
   build-go:

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,14 @@
 <Project>
+
+	<PropertyGroup>
+		<Authors>UnstoppableMango</Authors>
+		<RepositoryUrl>https://github.com/UnstoppableMango/tdl</RepositoryUrl>
+	</PropertyGroup>
+
 	<PropertyGroup>
 		<ProtoRoot>$(MSBuildThisFileDirectory)/proto</ProtoRoot>
 		<ProtoPkgDir>$(ProtoRoot)/unmango/dev/tdl</ProtoPkgDir>
 		<ProtoDir>$(ProtoPkgDir)/v1alpha1</ProtoDir>
 	</PropertyGroup>
+
 </Project>


### PR DESCRIPTION
The docs don't seem to mention this
https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-nuget-registry
But this github blog post from 2020 does
https://github.blog/changelog/2020-10-29-nuget-supports-api-key-option/

Quite frustrating.
