### PR TITLE
Added GitHub action for tagging go modules

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,0 +1,22 @@
+name: Tag go modules
+
+on:
+  release:
+    types: [released]
+
+jobs:
+  gomod:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        mod:
+          - cli
+          - gen
+          - pkg
+    steps:
+      - uses: actions/checkout@v4
+      - run: |
+          VERSION='${{ github.event.release.tag_name }}'
+          TAG="${{ matrix.mod }}/$VERSION"
+          git tag "$TAG"
+          git push origin "$TAG"


### PR DESCRIPTION
A new GitHub workflow has been added to automatically tag Go modules upon release. This workflow runs on the latest Ubuntu and applies to three modules: cli, gen, and pkg. The versioning is based on the release tag name.
