### PR TITLE
Convenience runner abstraction

### DIFF
--- a/src/Abstractions/Runner.cs
+++ b/src/Abstractions/Runner.cs
@@ -3,12 +3,12 @@ namespace UnMango.Tdl.Abstractions;
 [PublicAPI]
 public class Runner(IConverter converter, IGenerator generator) : IRunner
 {
-	public virtual Task<Spec> FromAsync(ISource source, CancellationToken cancellationToken = default) {
-		return converter.FromAsync(source, cancellationToken);
+	public virtual Task<Spec> FromAsync(Stream input, CancellationToken cancellationToken = default) {
+		return converter.FromAsync(input, cancellationToken);
 	}
 
-	public virtual Task GenerateAsync(Spec spec, ITarget target, CancellationToken cancellationToken = default) {
-		return generator.GenerateAsync(spec, target, cancellationToken);
+	public virtual Task GenerateAsync(Spec spec, Stream output, CancellationToken cancellationToken = default) {
+		return generator.GenerateAsync(spec, output, cancellationToken);
 	}
 
 	public Runner With(IConverter next) => new(next, generator);

--- a/src/Abstractions/Runner.cs
+++ b/src/Abstractions/Runner.cs
@@ -1,0 +1,23 @@
+namespace UnMango.Tdl.Abstractions;
+
+[PublicAPI]
+public class Runner(IConverter converter, IGenerator generator) : IRunner
+{
+	public virtual Task<Spec> FromAsync(ISource source, CancellationToken cancellationToken = default) {
+		return converter.FromAsync(source, cancellationToken);
+	}
+
+	public virtual Task GenerateAsync(Spec spec, ITarget target, CancellationToken cancellationToken = default) {
+		return generator.GenerateAsync(spec, target, cancellationToken);
+	}
+
+	public Runner With(IConverter next) => new(next, generator);
+	public Runner With(IGenerator next) => new(converter, next);
+}
+
+[PublicAPI]
+public static class RunnerExtensions
+{
+	public static IRunner With(this IRunner runner, IConverter converter) => new Runner(converter, runner);
+	public static IRunner With(this IRunner runner, IGenerator generator) => new Runner(runner, generator);
+}


### PR DESCRIPTION
For grouping a converter and a generator in situations where the domain doesn't have any runner-specific details