### PR TITLE
Updated editor configuration

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,12 +5,14 @@ indent_size = 2
 indent_style = tab
 insert_final_newline = true
 trim_trailing_whitespace = true
+max_line_length = 120
 
 [*.{yml,yaml}]
 indent_style = space
 
 [*.fs]
 indent_style = space
+max_line_length = 100
 fsharp_newline_before_multiline_computation_expression = false
 
 [*.cs]


### PR DESCRIPTION
Added maximum line length rules to the editor configuration. The general rule is now 120 characters, but for F# files it's specifically set to 100 characters.
