### PR TITLE
Added support for running in container

### DIFF
--- a/src/FSharp/Config.fs
+++ b/src/FSharp/Config.fs
@@ -35,6 +35,13 @@ module Config =
 
   let ownerLabel = "tdl.owner"
 
+  let runningInContainer = envSet "DOTNET_RUNNING_IN_CONTAINER"
+
+  let pluginDir (env: Env) : string =
+    match env, runningInContainer with
+    | _, true -> "/app/plugins"
+    | _ -> Directory.CreateTempSubdirectory("tdl").FullName
+
   let socketDir: Env -> string =
     function
     | _ -> Path.Combine(appdata, "tdl")


### PR DESCRIPTION
The code now checks if the application is running inside a container. If it is, the plugin directory is set to "/app/plugins". Otherwise, a temporary subdirectory "tdl" is created and used as the plugin directory.
