### PR TITLE
Added runtime identifier to build process

### DIFF
--- a/.github/actions/build-cs/action.yml
+++ b/.github/actions/build-cs/action.yml
@@ -20,6 +20,9 @@ inputs:
   restore-tools:
     description: Run dotnet tool restore
     default: 'false'
+  runtime-id:
+    description: The runtime identifier to use
+    default: linux-x64
 
 outputs:
   artifact-id:
@@ -41,12 +44,16 @@ runs:
 
     - name: Restore dependencies
       shell: bash
-      run: dotnet restore ${{ inputs.path }}
+      run: |
+        dotnet restore \
+          --runtime ${{ inputs.runtime-id }} \
+          ${{ inputs.path }}
 
     - name: Build
       shell: bash
       run: |
         dotnet build \
+          --runtime ${{ inputs.runtime-id }} \
           --configuration ${{ inputs.configuration }} \
           --no-restore \
           ${{ inputs.path }}
@@ -55,6 +62,7 @@ runs:
       shell: bash
       run: |
         dotnet test \
+          --runtime ${{ inputs.runtime-id }} \
           --configuration ${{ inputs.configuration }} \
           --collect:"XPlat Code Coverage" \
           --no-build \
@@ -81,6 +89,7 @@ runs:
       shell: bash
       run: |
         dotnet pack \
+          --runtime ${{ inputs.runtime-id }} \
           --configuration ${{ inputs.configuration }} \
           --output out \
           --no-build \


### PR DESCRIPTION
The build process has been updated to include a new input for the runtime identifier. This allows for specifying the target runtime during the restore, build, test, and pack steps. The default value is set to 'linux-x64'.
