### PR TITLE
Updated dotnet pack command in GitHub action

### DIFF
--- a/.github/actions/build-cs/action.yml
+++ b/.github/actions/build-cs/action.yml
@@ -89,7 +89,7 @@ runs:
       shell: bash
       run: |
         dotnet pack \
-          --runtime ${{ inputs.runtime-id }} \
+          --use-current-runtime \
           --configuration ${{ inputs.configuration }} \
           --output out \
           --no-build \


### PR DESCRIPTION
The dotnet pack command in the GitHub action has been updated. Instead of specifying a runtime ID, it now uses the current runtime. This change simplifies the build process and ensures compatibility with the environment where the action is running.
