### PR TITLE
Updated package matching rule in Renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -18,7 +18,9 @@
 	"packageRules": [
 		{
 			"groupName": "tdl",
-			"matchDepNames": "UnstoppableMango/tdl"
+			"matchPackagePatterns": [
+				"unstoppablemango/tdl"
+			]
 		}
 	]
 }


### PR DESCRIPTION
The renovate configuration has been updated to use "matchPackagePatterns" instead of "matchDepNames". This change allows for more flexible and pattern-based package matching.
