### PR TITLE
Updated renovate.json configuration

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -11,12 +11,12 @@
 			"datasourceTemplate": "github-releases",
 			"fileMatch": [
 				"package.json",
-				".*\\/action.yml"
+				".*\\/action\\.ya?ml"
 			],
-			"extractVersionTemplate": "bun-v(?<version>.*?)",
+			"extractVersionTemplate": "[Bb]un[- ]v(?<version>.*)",
 			"matchStrings": [
-				"\"packageManager\": \"bun@(?<currentValue>.*?)\"",
-				"bun-version: (?<currentValue>.*?)"
+				"\"packageManager\": \"bun@(?<currentValue>.*)\"",
+				"bun-version: (?<currentValue>.*)"
 			]
 		}
 	],


### PR DESCRIPTION
The renovate.json file has been updated to improve the matching and extraction of versions. The changes include:
- Modified the fileMatch pattern to match both .yml and .yaml files.
- Updated the extractVersionTemplate to be case-insensitive and allow for a space or hyphen between 'bun' and 'v'.
- Adjusted the matchStrings for packageManager and bun-version to capture all characters after '@' or ':'.
