### PR TITLE
Updated renovate.json with new package group

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -26,6 +26,12 @@
 			"matchPackagePatterns": [
 				"unstoppablemango/tdl"
 			]
+		},
+		{
+			"groupName": "bun",
+			"matchPackagePatterns": [
+				"oven-sh/bun"
+			]
 		}
 	]
 }


### PR DESCRIPTION
A new package group named 'bun' has been added to the renovate.json configuration file. This group is set to match packages from the 'oven-sh/bun' pattern.
