### PR TITLE
Updated Bun version reference in GitHub actions

### DIFF
--- a/.github/actions/build-bun/action.yml
+++ b/.github/actions/build-bun/action.yml
@@ -12,7 +12,7 @@ runs:
     - name: Setup Bun
       uses: oven-sh/setup-bun@v2
       with:
-        bun-version: 1.1.17
+        bun-version-file: package.json
 
     - name: Restore dependencies
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.1.17
+          bun-version-file: package.json
 
       - run: bun install --frozen-lockfile
 
@@ -45,7 +45,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.1.17
+          bun-version-file: package.json
 
       - run: bun install --frozen-lockfile
       - run: bun lint:md

--- a/.github/workflows/cli-um.yml
+++ b/.github/workflows/cli-um.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.1.17
+          bun-version-file: package.json
 
       - name: Bun install
         run: bun install --frozen-lockfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.1.17
+          bun-version-file: package.json
 
       - name: Restore dependencies
         working-directory: packages/${{ matrix.tool }}


### PR DESCRIPTION
The Bun version reference has been updated across multiple GitHub action workflows. Instead of hardcoding the version number, we now refer to it from the package.json file. This change will make maintaining and updating the Bun version more manageable and less error-prone.
