### PR TITLE
Enhanced CLI command descriptions

### DIFF
--- a/cli/internal/from.go
+++ b/cli/internal/from.go
@@ -17,7 +17,9 @@ type FromCmdOptions struct {
 
 func NewFromCmd[T uml.NewConverter[FromCmdOptions]](create T) *cobra.Command {
 	return &cobra.Command{
-		Use: "from",
+		Use:   "from [file...]",
+		Short: "Generate a UMl spec from source code",
+		Long:  `Searches file(s) for types and generates a UMl spec describing them`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			log := GetLogger(cmd)
 			opts := FromCmdOptions{Log: log}

--- a/cli/internal/gen.go
+++ b/cli/internal/gen.go
@@ -17,7 +17,9 @@ type GenCmdOptions struct {
 
 func NewGenCmd[T uml.NewGenerator[GenCmdOptions]](create T) *cobra.Command {
 	return &cobra.Command{
-		Use: "gen",
+		Use:   "gen [spec...]",
+		Short: "Generate source code types from the supplied spec(s)",
+		Long:  `Generate source code types from the supplied spec(s)`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			log := GetLogger(cmd)
 			opts := GenCmdOptions{Log: log}


### PR DESCRIPTION
Updated the 'from' and 'gen' commands in the CLI to include more detailed usage instructions. The 'from' command now generates a UML spec from source code, while the 'gen' command creates source code types from supplied specs.
