### PR TITLE
Remove eslint vscode settings option

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,4 @@
 {
-	"eslint.experimental.useFlatConfig": true,
 	"FSharp.autoRevealInExplorer": "sameAsFileExplorer",
 	"FSharp.showExplorerOnStartup": false,
 	"[dockerfile]": {


### PR DESCRIPTION
I think this is enabled by default now