### PR TITLE
Updated test suite to run serially

### DIFF
--- a/pkg/plugin/docker/plugin_test.go
+++ b/pkg/plugin/docker/plugin_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/unstoppablemango/tdl/pkg/plugin/docker"
 )
 
-var _ = Describe("Plugin", func() {
+var _ = Describe("Plugin", Serial, func() {
 	var testClient client.APIClient
 
 	BeforeEach(func() {


### PR DESCRIPTION
The test suite in the docker plugin package has been updated to run tests serially. This change was made by adding the 'Serial' tag to the 'Describe' function.
