### PR TITLE
Updated renovate configuration

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,8 @@
 {
 	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
 	"extends": [
-		"config:recommended"
+		"config:recommended",
+		"github>UnstoppableMango/renovate-config"
 	],
 	"automerge": true,
 	"schedule": [


### PR DESCRIPTION
The renovate.json file has been updated to extend from a new configuration. This change includes the addition of 'github>UnstoppableMango/renovate-config' to the extends array.
